### PR TITLE
`Key` option and TESSEL_AUTH_KEY

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -6,7 +6,7 @@ var controller = require('../lib/controller');
 var key = require('../lib/key');
 var init = require('../lib/init');
 var logs = require('../lib/logs');
-
+var TESSEL_AUTH_KEY = require('../lib/tessel/provision.js').TESSEL_AUTH_KEY;
 
 function closeSuccessfulCommand() {
   process.exit(0);
@@ -38,6 +38,13 @@ function makeCommand(commandName) {
     .option('name', {
       metavar: 'NAME',
       help: 'The name of the tessel on which the command will be executed'
+    })
+    .option('key', {
+      required: false,
+      metavar: 'PRIVATEKEY',
+      abbr: 'i',
+      default: TESSEL_AUTH_KEY,
+      help: 'RSA key for authorization with your Tessel'
     })
     .option('lan', {
       flag: true,

--- a/lib/tessel/provision.js
+++ b/lib/tessel/provision.js
@@ -258,6 +258,7 @@ util.inherits(AlreadyAuthenticatedError, Error);
 actions.AlreadyAuthenticatedError = AlreadyAuthenticatedError;
 
 module.exports = actions;
+module.exports.TESSEL_AUTH_KEY = filepath;
 
 if (global.IS_TEST_ENV) {
   module.exports = actions;

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -2,6 +2,11 @@ var sinon = require('sinon');
 var cli = require('../../bin/tessel-2');
 var controller = require('../../lib/controller');
 var logs = require('../../lib/logs');
+var path = require('path');
+var osenv = require('osenv');
+var directory = path.join(osenv.home(), '.tessel');
+var filename = 'id_rsa';
+var filepath = path.join(directory, filename);
 
 
 // If the defaults are intentionally changed in bin-tessel-2,
@@ -141,7 +146,8 @@ exports['Tessel (cli: update)'] = {
       0: 'update',
       version: 42,
       _: ['update'],
-      timeout: 5
+      timeout: 5,
+      key: filepath
     });
 
     cli(['update', '--list', ' ']);


### PR DESCRIPTION
As mentioned by @johnnyman727 at
https://github.com/tessel/t2-cli/pull/290/files#r39475328 and liked by
@wprater at https://github.com/tessel/t2-cli/pull/328/files#r39893445 I
am going to make a suggestion how to do by this pull request.
### Notes

It was necessary to change a test about `update` command (assume
@rwaldron wants to check this).
### Usage

Each command what likes to have a default value for the `option('key')`
would be able to use `TESSEL_AUTH_KEY`.
